### PR TITLE
fix: add Discord page

### DIFF
--- a/docs/src/pages/discord.mdoc
+++ b/docs/src/pages/discord.mdoc
@@ -1,0 +1,1 @@
+The Grit team is active on Discord. You can join using [this link](https://discord.gg/ARExD4gvFB).


### PR DESCRIPTION
Next.js deployed on GitHub pages doesn't support redirects so this is the simplest solution.